### PR TITLE
Enhance auto-tag workflow with manual trigger and tag checks

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -3,6 +3,7 @@ name: Auto Tag
 on:
   push:
     branches: [main]
+  workflow_dispatch: # permet de relancer manuellement si besoin
 
 permissions:
   contents: write
@@ -24,28 +25,28 @@ jobs:
           TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
           echo "tag=$TAG" >> $GITHUB_OUTPUT
 
-      - name: 🔎 Get commits since last tag
-        id: commits
+      - name: 🔎 Get commits since last tag (safe)
         run: |
+          git fetch --tags
+
           LAST_TAG="${{ steps.last_tag.outputs.tag }}"
 
           if [ -z "$LAST_TAG" ]; then
             echo "No tags found, using full history"
-            COMMITS=$(git log --pretty=%B)
+            git log --pretty=%B > commits.txt
           else
             echo "Last tag: $LAST_TAG"
-            COMMITS=$(git log $LAST_TAG..HEAD --pretty=%B)
+            git log $LAST_TAG..HEAD --pretty=%B > commits.txt
           fi
 
-          echo "commits<<EOF" >> $GITHUB_OUTPUT
-          echo "$COMMITS" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "Commits collected:"
+          cat commits.txt
 
       - name: 🔢 Compute next version
         id: bump
         run: |
           TAG="${{ steps.last_tag.outputs.tag }}"
-          COMMITS="${{ steps.commits.outputs.commits }}"
+          COMMITS=$(cat commits.txt)
 
           if [ -z "$TAG" ]; then
             TAG="v0.0.0"
@@ -57,7 +58,6 @@ jobs:
           MINOR=$(echo $TAG | cut -d. -f2)
           PATCH=$(echo $TAG | cut -d. -f3)
 
-          # 🔥 priorité : breaking change
           if echo "$COMMITS" | grep -q "BREAKING CHANGE"; then
             MAJOR=$((MAJOR+1))
             MINOR=0
@@ -77,17 +77,35 @@ jobs:
           fi
 
           NEW_TAG="v$MAJOR.$MINOR.$PATCH"
+
           echo "new_tag=$NEW_TAG" >> $GITHUB_OUTPUT
           echo "New tag: $NEW_TAG"
 
       - name: 🏷️ Create tag
         if: steps.bump.outputs.skip != 'true'
         run: |
+          NEW_TAG="${{ steps.bump.outputs.new_tag }}"
+
+          echo "Checking if tag exists locally..."
+          if git rev-parse "$NEW_TAG" >/dev/null 2>&1; then
+            echo "Tag already exists locally. Skipping."
+            exit 0
+          fi
+
+          echo "Checking if tag exists on remote..."
+          if git ls-remote --tags origin | grep -q "refs/tags/$NEW_TAG"; then
+            echo "Tag already exists on remote. Skipping."
+            exit 0
+          fi
+
           git config user.name "github-actions"
           git config user.email "actions@github.com"
 
-          git tag ${{ steps.bump.outputs.new_tag }}
-          git push origin ${{ steps.bump.outputs.new_tag }}
+          echo "Creating tag $NEW_TAG"
+          git tag "$NEW_TAG"
+
+          echo "Pushing tag $NEW_TAG"
+          git push origin "$NEW_TAG"
 
       - name: ℹ️ No version change
         if: steps.bump.outputs.skip == 'true'

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -8,8 +8,13 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: auto-tag
+  cancel-in-progress: false
+
 jobs:
   tag:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
 
     steps:
@@ -40,16 +45,9 @@ jobs:
           fi
 
           TOTAL_LINES=$(wc -l < commits.txt || echo 0)
-          echo "Commits collected (showing first 50 lines out of $TOTAL_LINES):"
+          echo "Commits collected (first 50 lines / $TOTAL_LINES total):"
           head -n 50 commits.txt || true
-          if [ "$TOTAL_LINES" -gt 50 ]; then
-            echo "... (output truncated; enable step debug logging to see full commits.txt) ..."
-          fi
 
-          if [ "${ACTIONS_STEP_DEBUG}" = "true" ]; then
-            echo "Full contents of commits.txt (step debug enabled):"
-            cat commits.txt
-          fi
       - name: 🔢 Compute next version
         id: bump
         run: |
@@ -61,20 +59,20 @@ jobs:
 
           echo "Current tag: $TAG"
 
-          MAJOR=$(echo $TAG | cut -d. -f1 | tr -d v)
-          MINOR=$(echo $TAG | cut -d. -f2)
-          PATCH=$(echo $TAG | cut -d. -f3)
+          MAJOR=$(echo "$TAG" | cut -d. -f1 | tr -d v)
+          MINOR=$(echo "$TAG" | cut -d. -f2)
+          PATCH=$(echo "$TAG" | cut -d. -f3)
 
           if grep -q "BREAKING CHANGE" commits.txt; then
             MAJOR=$((MAJOR+1))
             MINOR=0
             PATCH=0
 
-          elif grep -q "^feat" commits.txt; then
+          elif grep -qE "^feat(\(.+\))?:" commits.txt; then
             MINOR=$((MINOR+1))
             PATCH=0
 
-          elif grep -q "^fix" commits.txt; then
+          elif grep -qE "^fix(\(.+\))?:" commits.txt; then
             PATCH=$((PATCH+1))
 
           else
@@ -112,7 +110,16 @@ jobs:
           git tag "$NEW_TAG"
 
           echo "Pushing tag $NEW_TAG"
-          git push origin "$NEW_TAG"
+          git push origin "$NEW_TAG" || {
+            echo "Push failed, re-checking if tag exists..."
+            if git ls-remote --tags --refs origin "refs/tags/$NEW_TAG" | grep -q .; then
+              echo "Tag was created by another concurrent run. Treating as success."
+              exit 0
+            else
+              echo "Push failed for unknown reason."
+              exit 1
+            fi
+          }
 
       - name: ℹ️ No version change
         if: steps.bump.outputs.skip == 'true'

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -87,7 +87,7 @@ jobs:
           NEW_TAG="${{ steps.bump.outputs.new_tag }}"
 
           echo "Checking if tag exists locally..."
-          if git rev-parse "$NEW_TAG" >/dev/null 2>&1; then
+          if git show-ref --tags --verify --quiet "refs/tags/$NEW_TAG"; then
             echo "Tag already exists locally. Skipping."
             exit 0
           fi

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -3,7 +3,7 @@ name: Auto Tag
 on:
   push:
     branches: [main]
-  workflow_dispatch: # permet de relancer manuellement si besoin
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -39,9 +39,17 @@ jobs:
             git log "${LAST_TAG}..HEAD" --pretty=%B > commits.txt
           fi
 
-          echo "Commits collected:"
-          cat commits.txt
+          TOTAL_LINES=$(wc -l < commits.txt || echo 0)
+          echo "Commits collected (showing first 50 lines out of $TOTAL_LINES):"
+          head -n 50 commits.txt || true
+          if [ "$TOTAL_LINES" -gt 50 ]; then
+            echo "... (output truncated; enable step debug logging to see full commits.txt) ..."
+          fi
 
+          if [ "${ACTIONS_STEP_DEBUG}" = "true" ]; then
+            echo "Full contents of commits.txt (step debug enabled):"
+            cat commits.txt
+          fi
       - name: 🔢 Compute next version
         id: bump
         run: |

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -36,7 +36,7 @@ jobs:
             git log --pretty=%B > commits.txt
           else
             echo "Last tag: $LAST_TAG"
-            git log $LAST_TAG..HEAD --pretty=%B > commits.txt
+            git log "${LAST_TAG}..HEAD" --pretty=%B > commits.txt
           fi
 
           echo "Commits collected:"

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -93,7 +93,7 @@ jobs:
           fi
 
           echo "Checking if tag exists on remote..."
-          if git ls-remote --tags origin | grep -q "refs/tags/$NEW_TAG"; then
+          if git ls-remote --tags --refs origin "refs/tags/$NEW_TAG" | grep -q .; then
             echo "Tag already exists on remote. Skipping."
             exit 0
           fi

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -46,7 +46,6 @@ jobs:
         id: bump
         run: |
           TAG="${{ steps.last_tag.outputs.tag }}"
-          COMMITS=$(cat commits.txt)
 
           if [ -z "$TAG" ]; then
             TAG="v0.0.0"
@@ -58,16 +57,16 @@ jobs:
           MINOR=$(echo $TAG | cut -d. -f2)
           PATCH=$(echo $TAG | cut -d. -f3)
 
-          if echo "$COMMITS" | grep -q "BREAKING CHANGE"; then
+          if grep -q "BREAKING CHANGE" commits.txt; then
             MAJOR=$((MAJOR+1))
             MINOR=0
             PATCH=0
 
-          elif echo "$COMMITS" | grep -q "^feat"; then
+          elif grep -q "^feat" commits.txt; then
             MINOR=$((MINOR+1))
             PATCH=0
 
-          elif echo "$COMMITS" | grep -q "^fix"; then
+          elif grep -q "^fix" commits.txt; then
             PATCH=$((PATCH+1))
 
           else


### PR DESCRIPTION
This pull request updates the `auto-tag.yml` GitHub Actions workflow to improve safety, reliability, and manual control when automatically tagging releases. The main improvements are around ensuring tags are created and pushed safely, and making the workflow more robust when handling commit history and tags.

**Workflow improvements:**

* Added `workflow_dispatch` trigger to allow the workflow to be run manually from the GitHub UI, not just on pushes to `main`.

**Commit collection and version computation:**

* Improved the step that collects commits since the last tag by fetching tags before running `git log`, outputting commit messages to a file for safer handling, and displaying collected commits for easier debugging.
* Updated the version computation step to read commit messages from the file, ensuring consistency and avoiding issues with multi-line commit messages.

**Tag creation safety:**

* Enhanced the tag creation step to check if the new tag already exists locally or on the remote before attempting to create or push it, preventing errors and duplicate tags.

**Minor cleanup:**

* Removed a French comment and made minor formatting improvements for clarity.