### PR TITLE
Chore/add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Default ownership
+* @Astrea-EIP/team-back
+
+# GitHub workflows, repo automation, and CI config
+.github/ @Astrea-EIP/team-devops @CarlosSB2028
+
+# Documentation
+docs/ @CarlosSB2028


### PR DESCRIPTION
Adds CODEOWNERS configuration for repository ownership.

Includes:
- default ownership for the repository area
- DevOps ownership for GitHub workflows and repository automation
- CarlosSB2028 fallback ownership for documentation